### PR TITLE
check for priorday value, if 0 or null ignore

### DIFF
--- a/AppCode/ExportSettings.cs
+++ b/AppCode/ExportSettings.cs
@@ -202,7 +202,7 @@ namespace PortalRecordsMover.AppCode
 
             // if the prior days has been set, then override it with the calculated value 
             // this allows us to say, retrieve the last X days worth of records vs specifying a date
-            if (settings.Config.PriorDaysToRetrieve != null) 
+            if (settings.Config.PriorDaysToRetrieve != null || settings.Config.PriorDaysToRetrieve > 0) 
             {
                 // override and update based on date filter options
                 var dateFilter = now.AddDays((double)-settings.Config.PriorDaysToRetrieve);

--- a/ExportSettings.json
+++ b/ExportSettings.json
@@ -3,7 +3,10 @@
   "CreateFilter": "2017-11-24T12:00:00",
   "ModifyFilter": "2017-11-24T12:00:00",
 
-  "PriorDaysToRetrieve": "18",
+
+  /* Set to 0 to ignore
+  */
+  "PriorDaysToRetrieve": "0",
 
   /* Enum values, either number or name will work: CreateOnly=1, ModifyOnly, CreateAndModify
   */


### PR DESCRIPTION
checking the prior day config setting in ExportSettings and to avoid it failing as its a required field as below.

        [JsonProperty("PriorDaysToRetrieve", Required = Required.Always)]
        public long? PriorDaysToRetrieve { get; set; }

