### PR TITLE
Fix to case when username and password given from commandline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 packages/
 .vs/
+*.user

--- a/AppCode/ExportSettings.cs
+++ b/AppCode/ExportSettings.cs
@@ -164,10 +164,10 @@ namespace PortalRecordsMover.AppCode
                         settings.Config.SourceEnvironment = arg.Value;
                         break;
                     case "user":
-                        settings.Config.SourceEnvironment = arg.Value;
+                        settings.Config.Username = arg.Value;
                         break;
                     case "pass":
-                        settings.Config.SourceEnvironment = arg.Value;
+                        settings.Config.Password = arg.Value;
                         break;
 
                     case "batchcount":


### PR DESCRIPTION
Username and password given from commandline were incorrectly overriding source environment url.

Also *.user files are now excluded from repository as these may contain sensitive information.